### PR TITLE
Test Format action (TuringLang/actions#29)

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,25 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Format code
+        uses: TuringLang/actions/Format@sg-update-Formatter
+        with:
+          paths: julia-samples

--- a/julia-samples/example.jl
+++ b/julia-samples/example.jl
@@ -1,0 +1,22 @@
+module Example
+
+# Badly formatted Julia code for testing JuliaFormatter
+
+function add(x,y)
+return x+y
+end
+
+function greet( name )
+    println( "Hello, ", name,"!" )
+end
+
+struct Point
+x::Float64
+y::Float64
+end
+
+function distance(p1::Point,p2::Point)
+    sqrt((p1.x-p2.x)^2+(p1.y-p2.y)^2)
+end
+
+end

--- a/julia-samples/example.jl
+++ b/julia-samples/example.jl
@@ -2,20 +2,20 @@ module Example
 
 # Badly formatted Julia code for testing JuliaFormatter
 
-function add(x,y)
-return x+y
+function add(x, y)
+    return x+y
 end
 
-function greet( name )
-    println( "Hello, ", name,"!" )
+function greet(name)
+    println("Hello, ", name, "!")
 end
 
 struct Point
-x::Float64
-y::Float64
+    x::Float64
+    y::Float64
 end
 
-function distance(p1::Point,p2::Point)
+function distance(p1::Point, p2::Point)
     sqrt((p1.x-p2.x)^2+(p1.y-p2.y)^2)
 end
 


### PR DESCRIPTION
Tests the updated Format action from TuringLang/actions@sg-update-Formatter (TuringLang/actions#29).

- Runs formatter only on `julia-samples/` to avoid touching unrelated files
- `julia-samples/example.jl` is intentionally unformatted — reviewdog should suggest fixes on this PR

Generated by [Claude Code](https://claude.ai/code)