### PR TITLE
Test Runic formatter

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,26 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Format code
+        uses: TuringLang/actions/Format@sg-Runic
+        with:
+          formatter: runic
+          paths: julia-samples

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           formatter: runic
           paths: julia-samples
+          suggest-changes: true


### PR DESCRIPTION
Tests Runic via `TuringLang/actions/Format@sg-Runic`. Expects CI to fail on `julia-samples/example.jl` since it was formatted by JuliaFormatter, not Runic.